### PR TITLE
Support checking hashes on streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Check and get file hashes (using any algorithm)
 
 [![Build Status](https://travis-ci.org/ForbesLindesay/sha.png?branch=master)](https://travis-ci.org/ForbesLindesay/sha)
 [![Dependency Status](https://gemnasium.com/ForbesLindesay/sha.png)](https://gemnasium.com/ForbesLindesay/sha)
+[![NPM version](https://badge.fury.io/js/sha.png)](http://badge.fury.io/js/sha)
 
 ## Installation
 
@@ -27,6 +28,22 @@ Options:
 
 - algorithm: defaults to `sha1` and can be any of the algorithms supported by `crypto.createHash`
 
+### stream(expected, [options])
+
+Check the hash of a stream without ever buffering it.  This is a pass through stream so you can do things like:
+
+```js
+fs.createReadStream('src')
+  .pipe(sha.stream('expected'))
+  .pipe(fs.createWriteStream('dest'))
+```
+
+`dest` will be a complete copy of `src` and an error will be emitted if the hash did not match `'expected'`.
+
+Options:
+
+- algorithm: defaults to `sha1` and can be any of the algorithms supported by `crypto.createHash`
+
 ## License
 
-You may use this software under the BSD or MIT.  Take your pick.  If you want me to release it under another license, open an issue.
+You may use this software under the BSD or MIT.  Take your pick.  If you want me to release it under another license, open a pull request.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "license": "BSD",
   "optionalDependencies": {
-    "graceful-fs": "1.2"
+    "graceful-fs": "1.2",
+    "readable-stream": "1.0"
   },
   "devDependencies": {
     "mocha": "~1.9.0"


### PR DESCRIPTION
This adds a "through" stream that checks hashes as it goes.  That allows you to do the entire checking of a hash in memory without any buffering.

Will merge if there are no issues raised with this by 20313-06-08T17:00Z
