### PR TITLE
allow graceful-fs@3

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "BSD",
   "optionalDependencies": {
-    "graceful-fs": "2",
+    "graceful-fs": "2 || 3",
     "readable-stream": "1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
No major API change, still the exact same API as `fs`.  But, graceful-fs@3 doesn't club the global fs, it makes an exact copy (from the same code, even), and monkey-patches that instead.
