### PR TITLE
deps: Upgrade graceful-fs dependency to the latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "(BSD-2-Clause OR MIT)",
   "optionalDependencies": {
-    "graceful-fs": "2 || 3",
+    "graceful-fs": "^4.1.2",
     "readable-stream": "~1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
graceful-fs used to monkey-patch node's core fs module.
This has been fixed in the version 4.

Related: https://github.com/nodejs/node/pull/2714