### PR TITLE
Add meta to error in check

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,10 +22,14 @@ function check(file, expected, options, cb) {
       return cb(er)
     }
     if (actual === expected) return cb(null)
-    cb(new Error(
+    var err = new Error(
         'shasum check failed for ' + file + '\n'
       + 'Expected: ' + expected + '\n'
-      + 'Actual:   ' + actual))
+      + 'Actual:   ' + actual);
+    err.expected = expected;
+    err.actual = actual;
+    err.file = file;
+    cb(err);
   })
 }
 function checkSync(file, expected, options) {


### PR DESCRIPTION
This will add some of the metadata in `check` to the error object before giving it to the callback.