### PR TITLE
perf: remove readable-stream dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var Transform = require('stream').Transform || require('readable-stream').Transform
+var Transform = require('stream').Transform
 var crypto = require('crypto')
 var fs = require('graceful-fs')
 

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
   },
   "license": "(BSD-2-Clause OR MIT)",
   "dependencies": {
-    "graceful-fs": "^4.1.2",
-    "readable-stream": "^2.0.2"
+    "graceful-fs": "^4.1.2"
   },
   "devDependencies": {
     "mocha": "~1.9.0"


### PR DESCRIPTION
All supported node versions now have a sufficinetly up to date stream lib anyway.

BREAKING CHANGE: versions of node that don't have stream.Transform are no longer supported